### PR TITLE
Created .npmignore to not include test folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test
+deps


### PR DESCRIPTION
We received the following error in our GitHub repository. This is because the test folder is being published
![image](https://user-images.githubusercontent.com/19969687/109212612-082c4300-77b0-11eb-901a-9641aee6d52b.png)
